### PR TITLE
Fix ClContext::finishAll() not waiting for the default queue.

### DIFF
--- a/lib/backend.cc
+++ b/lib/backend.cc
@@ -898,6 +898,7 @@ bool ClContext::finishAll() {
     for (hipStream_t I : Queues) {
       Copies.push_back(I->getQueue());
     }
+    Copies.push_back(DefaultQueue->getQueue());
   }
 
   for (cl::CommandQueue &I : Copies) {


### PR DESCRIPTION
Hello,

While testing Babelstream on HIPCL we found out that `hipDeviceSynchronize()` didn't produce the desired effect. We tracked the problem down to `ClContext::finishAll()` not waiting for the `DefaultQueue`.

Thanks,

Brice