### PR TITLE
Changed matrix multiply validation to relative comparison.

### DIFF
--- a/samples/0_MatrixMultiply/MatrixMultiply.cpp
+++ b/samples/0_MatrixMultiply/MatrixMultiply.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <cfloat>
 
 // hip header file
 #include "hip/hip_runtime.h"
@@ -292,17 +293,18 @@ int main() {
 
     // verify the results
     size_t errors = 0;
-    float eps = 1.0;
+    float eps = FLT_EPSILON * 4;
     for (i = 0; i < WIDTH; i++) {
         for (j = 0; j < WIDTH; j++) {
           float cpu = cpuMultiplyMatrix[i*WIDTH+j];
           float gpu = MultiplyMatrix[i*WIDTH+j];
-          if (std::fabs(gpu - cpu) > eps) {
+          float diff = std::fabs(gpu - cpu);
+          if (diff > std::max(std::fabs(cpu), std::fabs(gpu)) * eps) {
             errors++;
             std::cout << "E[" << i << "][" << j << "]: M1 "
                       << Matrix1[i*WIDTH+j] << " M2 " << Matrix1[i*WIDTH+j]
                       << " CPU: " << cpu << " GPU: "
-                      << gpu << " ERROR: " << std::fabs(gpu - cpu) << "\n";
+                      << gpu << " ERROR: " << diff << "\n";
           }
         }
     }


### PR DESCRIPTION
Hello,

When deploying the recent fixes I noticed that the matrix multiply example was using an absolute value of 1.0 to compare the errors between cpu and gpu. In practice This was testing for exact equality as, for the range of numbers obtained, one ulp was about 32.0.

So I changed the code to use relative error measuring and set the threshold to `4 * FLT_EPSILON  * max(fabs(cpu), fab(gpu))`.
4 is the minimum value allowing the test to pass on our Intel gen9 gpus, but arguably you may want to set this constant to a higher value. In this case, the biggest recorded error was:
128.0 vs 3.11449e+08 (expected value) which corresponds to 4 ulp which is not surprising on an algorithm that reduces large amount of values.

Thanks