### PR TITLE
Add support for global variables and separate device compilation units

### DIFF
--- a/include/hip/hipcl.hh
+++ b/include/hip/hipcl.hh
@@ -383,6 +383,7 @@ typedef enum __HIP_NODISCARD hipError_t {
   hipErrorNotFound = 500,
   hipErrorIllegalAddress = 700,
   hipErrorInvalidSymbol = 701,
+  hipErrorNotSupported = 801,
   // Runtime Error Codes start here.
   hipErrorMissingConfiguration = 1001,
   hipErrorMemoryAllocation = 1002, ///< Memory allocation error.
@@ -1782,6 +1783,27 @@ hipError_t hipHostFree(void *ptr);
  */
 hipError_t hipMemcpy(void *dst, const void *src, size_t sizeBytes,
                      hipMemcpyKind kind);
+
+hipError_t hipModuleGetGlobal(hipDeviceptr_t *dptr, size_t *bytes,
+                              hipModule_t hmod, const char *name);
+
+hipError_t hipGetSymbolAddress(void **devPtr, const void *symbol);
+hipError_t hipGetSymbolSize(size_t *size, const void *symbol);
+hipError_t hipMemcpyToSymbol(const void *symbol, const void *src,
+                             size_t sizeBytes, size_t offset __dparm(0),
+                             hipMemcpyKind kind __dparm(hipMemcpyHostToDevice));
+hipError_t hipMemcpyToSymbolAsync(const void *symbol, const void *src,
+                                  size_t sizeBytes, size_t offset,
+                                  hipMemcpyKind kind,
+                                  hipStream_t stream __dparm(0));
+hipError_t
+hipMemcpyFromSymbol(void *dst, const void *symbol, size_t sizeBytes,
+                    size_t offset __dparm(0),
+                    hipMemcpyKind kind __dparm(hipMemcpyDeviceToHost));
+hipError_t hipMemcpyFromSymbolAsync(void *dst, const void *symbol,
+                                    size_t sizeBytes, size_t offset,
+                                    hipMemcpyKind kind,
+                                    hipStream_t stream __dparm(0));
 
 /**
  *  @brief Copy data from Host to Device

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -53,7 +53,31 @@ function(add_hipcl_binary EXEC_NAME)
 
 endfunction()
 
+# ARGN = sources
+function(add_hipcl_binary_device_link EXEC_NAME)
+    set(SOURCES ${ARGN})
+    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
 
+    add_executable("${EXEC_NAME}" ${SOURCES})
+
+    set_target_properties("${EXEC_NAME}" PROPERTIES CXX_STANDARD_REQUIRED ON)
+
+    target_link_libraries("${EXEC_NAME}" "${SANITIZER_LIBS}" "hipcl")
+
+    target_compile_options("hipcl" INTERFACE "-fgpu-rdc")
+
+    target_link_options("hipcl" INTERFACE
+	"--hip-link"
+	"$<INSTALL_INTERFACE:--hip-llvm-pass-path=${HIPCL_LLVM_DIR}>"
+	"$<BUILD_INTERFACE:--hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes>"
+	"$<INSTALL_INTERFACE:--hip-device-lib-path=${HIPCL_DATA_DIR}>"
+	"$<BUILD_INTERFACE:--hip-device-lib-path=${CMAKE_BINARY_DIR}>"
+	"--hip-device-lib=kernellib.bc")
+
+    install(TARGETS "${EXEC_NAME}"
+            RUNTIME DESTINATION "${HIPCL_SAMPLE_BINDIR}")
+
+endfunction()
 
 
 set(SAMPLES
@@ -74,6 +98,8 @@ set(SAMPLES
 #    7_streams
 #    9_unroll
     10_memcpy3D
+    hipSymbol
+    hipDeviceLink
 )
 
 foreach (SAMPLE ${SAMPLES})

--- a/samples/hipDeviceLink/CMakeLists.txt
+++ b/samples/hipDeviceLink/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Test symbol access
+
+add_hipcl_binary_device_link(
+	hipTestDeviceLink
+	hipDeviceLink.cpp
+	hipDeviceLinkRead.cpp
+	hipDeviceLinkWrite.cpp)
+
+add_test(NAME hipTestDeviceLink
+	 COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hipTestDeviceLink"
+	 )
+
+set_tests_properties(hipTestDeviceLink PROPERTIES
+	PASS_REGULAR_EXPRESSION PASSED)
+

--- a/samples/hipDeviceLink/hipDeviceLink.cpp
+++ b/samples/hipDeviceLink/hipDeviceLink.cpp
@@ -1,0 +1,21 @@
+#include "hipDeviceLinkConsts.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main() {
+  int *hostIn, *hostOut;
+  hostIn = new int[NUM];
+  hostOut = new int[NUM];
+  for (int i = 0; i < NUM; i++) {
+    hostIn[i] = -1 * i;
+    hostOut[i] = 0;
+  }
+  writeGlobal(hostIn);
+  readGlobal(hostOut);
+  for (int i = 0; i < NUM; i++) {
+    assert(hostIn[i] == hostOut[i]);
+  }
+  delete[] hostIn;
+  delete[] hostOut;
+  printf("PASSED!\n");
+}

--- a/samples/hipDeviceLink/hipDeviceLink.h
+++ b/samples/hipDeviceLink/hipDeviceLink.h
@@ -1,0 +1,3 @@
+#include "hipDeviceLinkConsts.h"
+#include <hip/hip_runtime.h>
+extern __device__ int global[NUM];

--- a/samples/hipDeviceLink/hipDeviceLinkConsts.h
+++ b/samples/hipDeviceLink/hipDeviceLinkConsts.h
@@ -1,0 +1,4 @@
+#define NUM 256
+#define SIZE 256 * sizeof(int)
+extern void readGlobal(int *hostOut);
+extern void writeGlobal(int *hostIn);

--- a/samples/hipDeviceLink/hipDeviceLinkRead.cpp
+++ b/samples/hipDeviceLink/hipDeviceLinkRead.cpp
@@ -1,0 +1,16 @@
+#include "hipDeviceLink.h"
+
+__device__ int global[NUM];
+
+__global__ void Read(int *out) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  out[tid] = global[tid];
+}
+
+void readGlobal(int *hostOut) {
+  int *deviceOut;
+  hipMalloc((void **)&deviceOut, SIZE);
+  hipLaunchKernelGGL(Read, dim3(1, 1, 1), dim3(NUM, 1, 1), 0, 0, deviceOut);
+  hipMemcpy(hostOut, deviceOut, SIZE, hipMemcpyDeviceToHost);
+  hipFree(deviceOut);
+}

--- a/samples/hipDeviceLink/hipDeviceLinkWrite.cpp
+++ b/samples/hipDeviceLink/hipDeviceLinkWrite.cpp
@@ -1,0 +1,14 @@
+#include "hipDeviceLink.h"
+
+__global__ void Write(const int *in) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  global[tid] = in[tid];
+}
+
+void writeGlobal(int *hostIn) {
+  int *deviceIn;
+  hipMalloc((void **)&deviceIn, SIZE);
+  hipMemcpy(deviceIn, hostIn, SIZE, hipMemcpyHostToDevice);
+  hipLaunchKernelGGL(Write, dim3(1, 1, 1), dim3(NUM, 1, 1), 0, 0, deviceIn);
+  hipFree(deviceIn);
+}

--- a/samples/hipSymbol/CMakeLists.txt
+++ b/samples/hipSymbol/CMakeLists.txt
@@ -1,0 +1,3 @@
+# Test symbol access
+
+add_hipcl_test(hipTestDeviceSymbol hipTestDeviceSymbol PASSED hipTestDeviceSymbol.cpp)

--- a/samples/hipSymbol/hipTestDeviceSymbol.cpp
+++ b/samples/hipSymbol/hipTestDeviceSymbol.cpp
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/* HIT_START
+ * BUILD: %t %s
+ * TEST: %t
+ * HIT_END
+ */
+
+#include <hip/hip_runtime.h>
+#include "test_common.h"
+#include <iostream>
+
+#define NUM 256
+#define SIZE 256 * 4
+
+__device__ int globalIn[NUM];
+__device__ int globalOut[NUM];
+
+__global__ void Assign(int* Out) {
+    int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    Out[tid] = globalIn[tid];
+    globalOut[tid] = globalIn[tid];
+}
+
+__device__ /*__constant__*/ int globalConst[NUM];
+
+__global__ void checkAddress(int* addr, bool* out) {
+    *out = ((intptr_t)globalConst == (intptr_t)addr);
+}
+
+int main() {
+    int *A, *Am, *B, *Ad, *C, *Cm;
+    A = new int[NUM];
+    B = new int[NUM];
+    C = new int[NUM];
+    for (int i = 0; i < NUM; i++) {
+        A[i] = -1 * i;
+        B[i] = 0;
+        C[i] = 0;
+    }
+
+    hipMalloc((void**)&Ad, SIZE);
+    hipHostMalloc((void**)&Am, SIZE);
+    hipHostMalloc((void**)&Cm, SIZE);
+    for (int i = 0; i < NUM; i++) {
+        Am[i] = -1 * i;
+        Cm[i] = 0;
+    }
+
+    hipStream_t stream;
+    hipStreamCreate(&stream);
+    hipMemcpyToSymbolAsync(HIP_SYMBOL(globalIn), Am, SIZE, 0, hipMemcpyHostToDevice, stream);
+    hipStreamSynchronize(stream);
+    hipLaunchKernelGGL(Assign, dim3(1, 1, 1), dim3(NUM, 1, 1), 0, 0, Ad);
+    hipMemcpy(B, Ad, SIZE, hipMemcpyDeviceToHost);
+    hipMemcpyFromSymbolAsync(Cm, HIP_SYMBOL(globalOut), SIZE, 0, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+    for (int i = 0; i < NUM; i++) {
+        assert(Am[i] == B[i]);
+        assert(Am[i] == Cm[i]);
+    }
+
+    for (int i = 0; i < NUM; i++) {
+        A[i] = -2 * i;
+        B[i] = 0;
+    }
+
+    hipMemcpyToSymbol(HIP_SYMBOL(globalIn), A, SIZE, 0, hipMemcpyHostToDevice);
+    hipLaunchKernelGGL(Assign, dim3(1, 1, 1), dim3(NUM, 1, 1), 0, 0, Ad);
+    hipMemcpy(B, Ad, SIZE, hipMemcpyDeviceToHost);
+    hipMemcpyFromSymbol(C, HIP_SYMBOL(globalOut), SIZE, 0, hipMemcpyDeviceToHost);
+    for (int i = 0; i < NUM; i++) {
+        assert(A[i] == B[i]);
+        assert(A[i] == C[i]);
+    }
+
+    for (int i = 0; i < NUM; i++) {
+        A[i] = -3 * i;
+        B[i] = 0;
+    }
+
+    hipMemcpyToSymbolAsync(HIP_SYMBOL(globalIn), A, SIZE, 0, hipMemcpyHostToDevice, stream);
+    hipStreamSynchronize(stream);
+    hipLaunchKernelGGL(Assign, dim3(1, 1, 1), dim3(NUM, 1, 1), 0, 0, Ad);
+    hipMemcpy(B, Ad, SIZE, hipMemcpyDeviceToHost);
+    hipMemcpyFromSymbolAsync(C, HIP_SYMBOL(globalOut), SIZE, 0, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+    for (int i = 0; i < NUM; i++) {
+        assert(A[i] == B[i]);
+        assert(A[i] == C[i]);
+    }
+
+    bool *checkOkD;
+    bool checkOk = false;
+    size_t symbolSize = 0;
+    int *symbolAddress;
+    hipGetSymbolSize(&symbolSize, HIP_SYMBOL(globalConst));
+    hipGetSymbolAddress((void**) &symbolAddress, HIP_SYMBOL(globalConst));
+    hipMalloc((void**)&checkOkD, sizeof(bool));
+    hipLaunchKernelGGL(checkAddress, dim3(1, 1, 1), dim3(1, 1, 1), 0, 0, symbolAddress, checkOkD);
+    hipMemcpy(&checkOk, checkOkD, sizeof(bool), hipMemcpyDeviceToHost);
+    hipFree(checkOkD);
+    assert(symbolSize == SIZE);
+    assert(checkOk);
+
+    hipHostFree(Am);
+    hipHostFree(Cm);
+    hipFree(Ad);
+    delete[] A;
+    delete[] B;
+    delete[] C;
+    passed();
+}

--- a/samples/hipSymbol/test_common.h
+++ b/samples/hipSymbol/test_common.h
@@ -1,0 +1,543 @@
+/*
+Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/*
+ * File is intended to C and CPP compliant hence any CPP specic changes
+ * should be added into CPP section
+ *
+ */
+
+#ifdef __cplusplus
+    #include <iostream>
+    #include <iomanip>
+    #if __CUDACC__
+        #include <sys/time.h>
+    #else
+        #include <chrono>
+    #endif
+#endif
+
+// ************************ GCC section **************************
+#include <stddef.h>
+
+#include "hip/hip_runtime.h"
+
+#define HC __attribute__((hc))
+
+#define KNRM "\x1B[0m"
+#define KRED "\x1B[31m"
+#define KGRN "\x1B[32m"
+#define KYEL "\x1B[33m"
+#define KBLU "\x1B[34m"
+#define KMAG "\x1B[35m"
+#define KCYN "\x1B[36m"
+#define KWHT "\x1B[37m"
+
+  // HIP Skip Return code set at cmake
+#define HIP_SKIP_RETURN_CODE 127
+#define HIP_ENABLE_SKIP_TESTS 0
+
+inline bool hip_skip_tests_enabled() {
+  return HIP_ENABLE_SKIP_TESTS;
+}
+
+inline int hip_skip_retcode() {
+  // HIP Skip Return code set at cmake
+  return HIP_SKIP_RETURN_CODE;
+}
+
+#define passed()                                                                                   \
+    printf("%sPASSED!%s\n", KGRN, KNRM);                                                           \
+    exit(0);
+
+// The real "assert" would have written to stderr. But it is
+// sufficient to just fflush here without getting pedantic. This also
+// ensures that we don't lose any earlier writes to stdout.
+#define failed(...)                                                                                \
+    printf("%serror: ", KRED);                                                                     \
+    printf(__VA_ARGS__);                                                                           \
+    printf("\n");                                                                                  \
+    printf("error: TEST FAILED\n%s", KNRM);                                                        \
+    fflush(NULL);                                                                               \
+    abort();
+
+#define warn(...)                                                                                  \
+    printf("%swarn: ", KYEL);                                                                      \
+    printf(__VA_ARGS__);                                                                           \
+    printf("\n");                                                                                  \
+    printf("warn: TEST WARNING\n%s", KNRM);
+
+#define HIP_PRINT_STATUS(status)                                                                   \
+    std::cout << hipGetErrorName(status) << " at line: " << __LINE__ << std::endl;
+
+#define HIPCHECK(error)                                                                            \
+    {                                                                                              \
+        hipError_t localError = error;                                                             \
+        if ((localError != hipSuccess) && (localError != hipErrorPeerAccessAlreadyEnabled)) {      \
+            printf("%serror: '%s'(%d) from %s at %s:%d%s\n", KRED, hipGetErrorString(localError),  \
+                   localError, #error, __FILE__, __LINE__, KNRM);                                  \
+            failed("API returned error code.");                                                    \
+        }                                                                                          \
+    }
+
+#define HIPASSERT(condition)                                                                       \
+    if (!(condition)) {                                                                            \
+        failed("%sassertion %s at %s:%d%s \n", KRED, #condition, __FILE__, __LINE__, KNRM);        \
+    }
+
+
+#define HIPCHECK_API(API_CALL, EXPECTED_ERROR)                                                     \
+    {                                                                                              \
+        hipError_t _e = (API_CALL);                                                                \
+        if (_e != (EXPECTED_ERROR)) {                                                              \
+            failed("%sAPI '%s' returned %d(%s) but test expected %d(%s) at %s:%d%s \n", KRED,      \
+                   #API_CALL, _e, hipGetErrorName(_e), EXPECTED_ERROR,                             \
+                   hipGetErrorName(EXPECTED_ERROR), __FILE__, __LINE__, KNRM);                     \
+        }                                                                                          \
+    }
+
+#ifdef _WIN64
+#include <tchar.h>
+#define aligned_alloc(x,y) _aligned_malloc(y,x)
+#define aligned_free(x) _aligned_free(x)
+#define popen(x,y) _popen(x,y)
+#define pclose(x) _pclose(x)
+#define setenv(x,y,z) _putenv_s(x,y)
+#define unsetenv _putenv
+#define fileno(x) _fileno(x)
+#define dup(x) _dup(x)
+#define dup2(x,y) _dup2(x,y)
+#define close(x) _close(x)
+#else
+#define aligned_free(x) free(x)
+#endif
+
+// standard command-line variables:
+extern size_t N;
+extern char memsetval;
+extern int memsetD32val;
+extern short memsetD16val;
+extern char memsetD8val;
+extern int iterations;
+extern unsigned blocksPerCU;
+extern unsigned threadsPerBlock;
+extern int p_gpuDevice;
+extern unsigned p_verbose;
+extern int p_tests;
+extern const char* HIP_VISIBLE_DEVICES_STR;
+extern const char* CUDA_VISIBLE_DEVICES_STR;
+extern const char* PATH_SEPERATOR_STR;
+extern const char* NULL_DEVICE;
+
+// ********************* CPP section *********************
+#ifdef __cplusplus
+
+#ifdef __HIP_PLATFORM_HCC
+#define TYPENAME(T) typeid(T).name()
+#else
+#define TYPENAME(T) "?"
+#endif
+
+namespace HipTest {
+
+// Returns the current system time in microseconds
+inline long long get_time() {
+#if __CUDACC__
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return (tv.tv_sec * 1000000) + tv.tv_usec;
+#else
+    return std::chrono::high_resolution_clock::now().time_since_epoch()
+        /std::chrono::microseconds(1);
+#endif
+}
+
+double elapsed_time(long long startTimeUs, long long stopTimeUs);
+
+int parseSize(const char* str, size_t* output);
+int parseUInt(const char* str, unsigned int* output);
+int parseInt(const char* str, int* output);
+int parseStandardArguments(int argc, char* argv[], bool failOnUndefinedArg);
+
+unsigned setNumBlocks(unsigned blocksPerCU, unsigned threadsPerBlock, size_t N);
+
+template<typename T> // pointer type
+void checkArray(T hData, T hOutputData, size_t width, size_t height,size_t depth)
+{
+   for (int i = 0; i < depth; i++) {
+      for (int j = 0; j < height; j++) {
+          for (int k = 0; k < width; k++) {
+              int offset = i*width*height + j*width + k;
+              if (hData[offset] != hOutputData[offset]) {
+                  std::cerr << '[' << i << ',' << j << ',' << k << "]:" << hData[offset] << "----" << hOutputData[offset]<<"  ";
+                  failed("mistmatch at:%d %d %d",i,j,k);
+              }
+          }
+       }
+   }
+}
+
+template<typename T> 
+void checkArray(T input, T output, size_t height, size_t width)
+{
+    for(int i=0; i<height; i++ ){
+        for(int j=0; j<width; j++ ){
+            int offset = i*width + j;
+            if( input[offset] !=  output[offset] ){
+                 std::cerr << '[' << i << ',' << j << ',' << "]:" << input[offset] << "----" << output[offset]<<"  ";
+                 failed("mistmatch at:%d %d",i,j);
+            }
+        }
+    }
+}
+
+
+template <typename T>
+__global__ void vectorADD(const T* A_d, const T* B_d, T* C_d, size_t NELEM) {
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    for (size_t i = offset; i < NELEM; i += stride) {
+        C_d[i] = A_d[i] + B_d[i];
+    }
+}
+
+
+template <typename T>
+__global__ void vectorADDReverse(const T* A_d, const T* B_d, T* C_d,
+                                 size_t NELEM) {
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
+        C_d[i] = A_d[i] + B_d[i];
+    }
+}
+
+
+template <typename T>
+__global__ void addCount(const T* A_d, T* C_d, size_t NELEM, int count) {
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    // Deliberately do this in an inefficient way to increase kernel runtime
+    for (int i = 0; i < count; i++) {
+        for (size_t i = offset; i < NELEM; i += stride) {
+            C_d[i] = A_d[i] + (T)count;
+        }
+    }
+}
+
+
+template <typename T>
+__global__ void addCountReverse(const T* A_d, T* C_d, int64_t NELEM, int count) {
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    // Deliberately do this in an inefficient way to increase kernel runtime
+    for (int i = 0; i < count; i++) {
+        for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
+            C_d[i] = A_d[i] + (T)count;
+        }
+    }
+}
+
+
+template <typename T>
+__global__ void memsetReverse(T* C_d, T val, int64_t NELEM) {
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+    size_t stride = blockDim.x * gridDim.x;
+
+    for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
+        C_d[i] = val;
+    }
+}
+
+
+template <typename T>
+void setDefaultData(size_t numElements, T* A_h, T* B_h, T* C_h) {
+    // Initialize the host data:
+    for (size_t i = 0; i < numElements; i++) {
+        if (A_h) (A_h)[i] = 3.146f + i;  // Pi
+        if (B_h) (B_h)[i] = 1.618f + i;  // Phi
+        if (C_h) (C_h)[i] = 0.0f + i;
+    }
+}
+
+
+template <typename T>
+void initArraysForHost(T** A_h, T** B_h, T** C_h, size_t N, bool usePinnedHost = false) {
+    size_t Nbytes = N * sizeof(T);
+
+    if (usePinnedHost) {
+        if (A_h) {
+            HIPCHECK(hipHostMalloc((void**)A_h, Nbytes));
+        }
+        if (B_h) {
+            HIPCHECK(hipHostMalloc((void**)B_h, Nbytes));
+        }
+        if (C_h) {
+            HIPCHECK(hipHostMalloc((void**)C_h, Nbytes));
+        }
+    } else {
+        if (A_h) {
+            *A_h = (T*)malloc(Nbytes);
+            HIPASSERT(*A_h != NULL);
+        }
+
+        if (B_h) {
+            *B_h = (T*)malloc(Nbytes);
+            HIPASSERT(*B_h != NULL);
+        }
+
+        if (C_h) {
+            *C_h = (T*)malloc(Nbytes);
+            HIPASSERT(*C_h != NULL);
+        }
+    }
+
+    setDefaultData(N, A_h ? *A_h : NULL, B_h ? *B_h : NULL, C_h ? *C_h : NULL);
+}
+
+
+template <typename T>
+void initArrays(T** A_d, T** B_d, T** C_d, T** A_h, T** B_h, T** C_h, size_t N,
+                bool usePinnedHost = false) {
+    size_t Nbytes = N * sizeof(T);
+
+    if (A_d) {
+        HIPCHECK(hipMalloc(A_d, Nbytes));
+    }
+    if (B_d) {
+        HIPCHECK(hipMalloc(B_d, Nbytes));
+    }
+    if (C_d) {
+        HIPCHECK(hipMalloc(C_d, Nbytes));
+    }
+
+    initArraysForHost(A_h, B_h, C_h, N, usePinnedHost);
+}
+
+
+template <typename T>
+void freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
+    if (usePinnedHost) {
+        if (A_h) {
+            HIPCHECK(hipHostFree(A_h));
+        }
+        if (B_h) {
+            HIPCHECK(hipHostFree(B_h));
+        }
+        if (C_h) {
+            HIPCHECK(hipHostFree(C_h));
+        }
+    } else {
+        if (A_h) {
+            free(A_h);
+        }
+        if (B_h) {
+            free(B_h);
+        }
+        if (C_h) {
+            free(C_h);
+        }
+    }
+}
+
+template <typename T>
+void freeArrays(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
+    if (A_d) {
+        HIPCHECK(hipFree(A_d));
+    }
+    if (B_d) {
+        HIPCHECK(hipFree(B_d));
+    }
+    if (C_d) {
+        HIPCHECK(hipFree(C_d));
+    }
+
+    freeArraysForHost(A_h, B_h, C_h, usePinnedHost);
+}
+
+#if defined(__HIP_PLATFORM_HCC__)
+template <typename T>
+void initArrays2DPitch(T** A_d, T** B_d, T** C_d, size_t* pitch_A, size_t* pitch_B, size_t* pitch_C,
+                       size_t numW, size_t numH) {
+    if (A_d) {
+        HIPCHECK(hipMallocPitch((void**)A_d, pitch_A, numW * sizeof(T), numH));
+    }
+    if (B_d) {
+        HIPCHECK(hipMallocPitch((void**)B_d, pitch_B, numW * sizeof(T), numH));
+    }
+    if (C_d) {
+        HIPCHECK(hipMallocPitch((void**)C_d, pitch_C, numW * sizeof(T), numH));
+    }
+
+    HIPASSERT(*pitch_A == *pitch_B);
+    HIPASSERT(*pitch_A == *pitch_C)
+}
+
+inline void initHIPArrays(hipArray** A_d, hipArray** B_d, hipArray** C_d,
+                          const hipChannelFormatDesc* desc, const size_t numW, const size_t numH,
+                          const unsigned int flags) {
+    if (A_d) {
+        HIPCHECK(hipMallocArray(A_d, desc, numW, numH, flags));
+    }
+    if (B_d) {
+        HIPCHECK(hipMallocArray(B_d, desc, numW, numH, flags));
+    }
+    if (C_d) {
+        HIPCHECK(hipMallocArray(C_d, desc, numW, numH, flags));
+    }
+}
+#endif
+
+// Assumes C_h contains vector add of A_h + B_h
+// Calls the test "failed" macro if a mismatch is detected.
+template <typename T>
+size_t checkVectorADD(T* A_h, T* B_h, T* result_H, size_t N, bool expectMatch = true,
+                      bool reportMismatch = true) {
+    size_t mismatchCount = 0;
+    size_t firstMismatch = 0;
+    size_t mismatchesToPrint = 10;
+    for (size_t i = 0; i < N; i++) {
+        T expected = A_h[i] + B_h[i];
+        if (result_H[i] != expected) {
+            if (mismatchCount == 0) {
+                firstMismatch = i;
+            }
+            mismatchCount++;
+            if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
+                std::cout << std::fixed << std::setprecision(32);
+                std::cout << "At " << i << std::endl;
+                std::cout << "  Computed:" << result_H[i] << std::endl;
+                std::cout << "  Expected:" << expected << std::endl;
+            }
+        }
+    }
+
+    if (reportMismatch) {
+        if (expectMatch) {
+            if (mismatchCount) {
+                failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
+            }
+        } else {
+            if (mismatchCount == 0) {
+                failed("expected mismatches but did not detect any!");
+            }
+        }
+    }
+
+    return mismatchCount;
+}
+
+
+// Assumes C_h contains vector add of A_h + B_h
+// Calls the test "failed" macro if a mismatch is detected.
+template <typename T>
+void checkTest(T* expected_H, T* result_H, size_t N, bool expectMatch = true) {
+    size_t mismatchCount = 0;
+    size_t firstMismatch = 0;
+    size_t mismatchesToPrint = 10;
+    for (size_t i = 0; i < N; i++) {
+        if (result_H[i] != expected_H[i]) {
+            if (mismatchCount == 0) {
+                firstMismatch = i;
+            }
+            mismatchCount++;
+            if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
+                std::cout << std::fixed << std::setprecision(32);
+                std::cout << "At " << i << std::endl;
+                std::cout << "  Computed:" << result_H[i] << std::endl;
+                std::cout << "  Expected:" << expected_H[i] << std::endl;
+            }
+        }
+    }
+
+    if (expectMatch) {
+        if (mismatchCount) {
+            fprintf(stderr, "%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
+            // failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
+        }
+    } else {
+        if (mismatchCount == 0) {
+            failed("expected mismatches but did not detect any!");
+        }
+    }
+}
+
+
+//---
+struct Pinned {
+    static const bool isPinned = true;
+    static const char* str() { return "Pinned"; };
+
+    static void* Alloc(size_t sizeBytes) {
+        void* p;
+        HIPCHECK(hipHostMalloc((void**)&p, sizeBytes));
+        return p;
+    };
+};
+
+
+//---
+struct Unpinned {
+    static const bool isPinned = false;
+    static const char* str() { return "Unpinned"; };
+
+    static void* Alloc(size_t sizeBytes) {
+        void* p = malloc(sizeBytes);
+        HIPASSERT(p);
+        return p;
+    };
+};
+
+
+struct Memcpy {
+    static const char* str() { return "Memcpy"; };
+};
+
+struct MemcpyAsync {
+    static const char* str() { return "MemcpyAsync"; };
+};
+
+
+template <typename C>
+struct MemTraits;
+
+
+template <>
+struct MemTraits<Memcpy> {
+    static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+                     hipStream_t stream) {
+        HIPCHECK(hipMemcpy(dest, src, sizeBytes, kind));
+    }
+};
+
+
+template <>
+struct MemTraits<MemcpyAsync> {
+    static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+                     hipStream_t stream) {
+        HIPCHECK(hipMemcpyAsync(dest, src, sizeBytes, kind, stream));
+    }
+};
+
+};  // namespace HipTest
+#endif //__cplusplus


### PR DESCRIPTION
Hello,

This pull request adds support for:
 - global variables through an Intel extension, the same strategy (generating a kernel at link time that can return the relevant global variable information) could be replicated as an additional compiler pass.
 - compiling modules only once per ClContext

This also adds tests for:
 - global variables
 - device linking

It requires an updated clang: https://github.com/cpc/hipcl-clang/pull/2

I know this is quite a lot of changes, but the two features are very interdependent unfortunately.

Thanks,
Brice