### PR TITLE
Various fixes.

### DIFF
--- a/lib/bitcode/CMakeLists.txt
+++ b/lib/bitcode/CMakeLists.txt
@@ -1,10 +1,17 @@
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/BC")
 
+#Ugly fix for interactions between clang13+ and igc
+if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13)
+  set(CLANG_CL_NO_STDINC_FLAG "")
+else ()
+  set(CLANG_CL_NO_STDINC_FLAG "-cl-no-stdinc")
+endif ()
+
 add_custom_command( OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/mathlib.bc"
                     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/mathlib.cl"
         COMMAND "${CMAKE_CXX_COMPILER}"
-        -Xclang -finclude-default-header
+        "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
         -O2 -x cl -cl-std=CL2.0
         --target=spir64-unknown-unknown -emit-llvm
         -o "${CMAKE_CURRENT_BINARY_DIR}/BC/mathlib.bc"
@@ -30,7 +37,7 @@ foreach(SOURCE IN LISTS SOURCES)
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/BC/${SOURCE}.bc"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/OCML/${SOURCE}.cl"
         COMMAND "${CMAKE_CXX_COMPILER}"
-        -Xclang -finclude-default-header
+        "${CLANG_CL_NO_STDINC_FLAG}" -Xclang -finclude-default-header
         -O2 -pthread -x cl -cl-std=CL2.0
         --target=spir64-unknown-unknown -emit-llvm
         -o "${CMAKE_CURRENT_BINARY_DIR}/BC/${SOURCE}.bc"

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -68,12 +68,12 @@ function(add_hipcl_binary_device_link EXEC_NAME)
 
     target_link_options("${EXEC_NAME}" PRIVATE
         "-fgpu-rdc"
-	"--hip-link"
-	"$<INSTALL_INTERFACE:--hip-llvm-pass-path=${HIPCL_LLVM_DIR}>"
-	"$<BUILD_INTERFACE:--hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes>"
-	"$<INSTALL_INTERFACE:--hip-device-lib-path=${HIPCL_DATA_DIR}>"
-	"$<BUILD_INTERFACE:--hip-device-lib-path=${CMAKE_BINARY_DIR}>"
-	"--hip-device-lib=kernellib.bc")
+        "--hip-link"
+        "$<INSTALL_INTERFACE:--hip-llvm-pass-path=${HIPCL_LLVM_DIR}>"
+        "$<BUILD_INTERFACE:--hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes>"
+        "$<INSTALL_INTERFACE:--hip-device-lib-path=${HIPCL_DATA_DIR}>"
+        "$<BUILD_INTERFACE:--hip-device-lib-path=${CMAKE_BINARY_DIR}>"
+        "--hip-device-lib=kernellib.bc")
 
     install(TARGETS "${EXEC_NAME}"
             RUNTIME DESTINATION "${HIPCL_SAMPLE_BINDIR}")

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -64,16 +64,16 @@ function(add_hipcl_binary_device_link EXEC_NAME)
 
     target_link_libraries("${EXEC_NAME}" "${SANITIZER_LIBS}" "hipcl")
 
-    target_compile_options("hipcl" INTERFACE "-fgpu-rdc")
+    target_compile_options("${EXEC_NAME}" PRIVATE "-fgpu-rdc")
 
-    target_link_options("hipcl" INTERFACE
+    target_link_options("${EXEC_NAME}" PRIVATE
         "-fgpu-rdc"
-        "--hip-link"
-        "$<INSTALL_INTERFACE:--hip-llvm-pass-path=${HIPCL_LLVM_DIR}>"
-        "$<BUILD_INTERFACE:--hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes>"
-        "$<INSTALL_INTERFACE:--hip-device-lib-path=${HIPCL_DATA_DIR}>"
-        "$<BUILD_INTERFACE:--hip-device-lib-path=${CMAKE_BINARY_DIR}>"
-        "--hip-device-lib=kernellib.bc")
+	"--hip-link"
+	"$<INSTALL_INTERFACE:--hip-llvm-pass-path=${HIPCL_LLVM_DIR}>"
+	"$<BUILD_INTERFACE:--hip-llvm-pass-path=${CMAKE_BINARY_DIR}/llvm_passes>"
+	"$<INSTALL_INTERFACE:--hip-device-lib-path=${HIPCL_DATA_DIR}>"
+	"$<BUILD_INTERFACE:--hip-device-lib-path=${CMAKE_BINARY_DIR}>"
+	"--hip-device-lib=kernellib.bc")
 
     install(TARGETS "${EXEC_NAME}"
             RUNTIME DESTINATION "${HIPCL_SAMPLE_BINDIR}")


### PR DESCRIPTION
This pull request fixes 2 issues:
 - a097a59 (and d5f1631) fix the fact that -fgpu-rdc was applied to all sample compilation. `add_hipcl_test` and `add_hipcl_binary` would also apply the flag (I am not the most familiar with CMake, sorry about this mistake)
 - 63f7371 works around an issue where clang would use the wrong version of opencl-c-base.h if it is in the CPATH, preventing some valid programs from compiling. The issue is being investigated, but in the meantime, the workaround seems harmless enough.

Fell free to cherry pick those if you prefer separate contributions.