### PR TITLE
Fix support for `hipModuleLoad` + `hipModuleLaunchKernel` when used with the `extra` parameter

### DIFF
--- a/lib/backend.cc
+++ b/lib/backend.cc
@@ -1119,7 +1119,7 @@ hipError_t ClContext::launchWithKernelParams(dim3 grid, dim3 block,
     return hipErrorLaunchFailure;
   }
 
-  return stream->launch3(kernel, grid, block);
+  return Queue->launch3(kernel, grid, block);
 }
 
 hipError_t ClContext::launchWithExtraParams(dim3 grid, dim3 block,
@@ -1141,7 +1141,7 @@ hipError_t ClContext::launchWithExtraParams(dim3 grid, dim3 block,
       p += 2;
       continue;
     } else if (*p == HIP_LAUNCH_PARAM_BUFFER_SIZE) {
-      size = (size_t)p[1];
+      size = *(size_t *)p[1];
       p += 2;
       continue;
     } else {
@@ -1166,7 +1166,7 @@ hipError_t ClContext::launchWithExtraParams(dim3 grid, dim3 block,
     logError("Failed to set kernel arguments for launch! \n");
     return hipErrorLaunchFailure;
   }
-  return stream->launch3(kernel, grid, block);
+  return Queue->launch3(kernel, grid, block);
 }
 
 ClProgram *ClContext::createProgram(std::string &binary) {

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -54,6 +54,33 @@ function(add_hipcl_binary EXEC_NAME)
 endfunction()
 
 # ARGN = sources
+function(add_hipcl_device_binary BIN_NAME)
+    set(SOURCES ${ARGN})
+
+    set(BIN_NAME_OBJ "${BIN_NAME}_o")
+
+    add_library("${BIN_NAME_OBJ}" OBJECT ${SOURCES})
+
+    set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
+
+    target_link_libraries("${BIN_NAME_OBJ}" "${SANITIZER_LIBS}" "hipcl")
+
+    target_compile_options("${BIN_NAME_OBJ}" PRIVATE "--cuda-device-only")
+
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}"
+                       COMMAND ${CMAKE_COMMAND} -E copy
+                               $<TARGET_OBJECTS:${BIN_NAME_OBJ}>
+                               "${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}"
+                       DEPENDS "${BIN_NAME_OBJ}")
+
+    add_custom_target("${BIN_NAME}" DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}")
+
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${BIN_NAME}"
+            DESTINATION "${HIPCL_SAMPLE_BINDIR}")
+
+endfunction()
+
+# ARGN = sources
 function(add_hipcl_binary_device_link EXEC_NAME)
     set(SOURCES ${ARGN})
     set_source_files_properties(${SOURCES} PROPERTIES LANGUAGE CXX)
@@ -101,6 +128,7 @@ set(SAMPLES
     10_memcpy3D
     hipSymbol
     hipDeviceLink
+    hiploadmodule
 )
 
 foreach (SAMPLE ${SAMPLES})

--- a/samples/hiploadmodule/CMakeLists.txt
+++ b/samples/hiploadmodule/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Test symbol access
+
+add_hipcl_binary(
+	hipModuleLoad
+	main.cpp)
+
+add_hipcl_device_binary(
+	hipModuleLoadBinary
+	kernel.cpp)
+
+add_dependencies(hipModuleLoad hipModuleLoadBinary)
+
+add_test(NAME hipModuleLoad
+	 COMMAND "${CMAKE_CURRENT_BINARY_DIR}/hipModuleLoad"
+	 )
+
+set_tests_properties(hipModuleLoad PROPERTIES
+	PASS_REGULAR_EXPRESSION PASSED)
+

--- a/samples/hiploadmodule/kernel.cpp
+++ b/samples/hiploadmodule/kernel.cpp
@@ -1,0 +1,12 @@
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void _occa_addVectors_0(const size_t entries,
+					      const float * a,
+					      const float * b,
+					      float * ab) {
+
+    size_t i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+    if (i < entries) {
+        ab[i] = a[i] + b[i];
+    }
+}

--- a/samples/hiploadmodule/kernel.cpp
+++ b/samples/hiploadmodule/kernel.cpp
@@ -1,12 +1,11 @@
 #include <hip/hip_runtime.h>
 
 extern "C" __global__ void _occa_addVectors_0(const size_t entries,
-					      const float * a,
-					      const float * b,
-					      float * ab) {
-
-    size_t i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
-    if (i < entries) {
-        ab[i] = a[i] + b[i];
-    }
+                                              const float * a,
+                                              const float * b,
+                                              float * ab) {
+  size_t i = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+  if (i < entries) {
+    ab[i] = a[i] + b[i];
+  }
 }

--- a/samples/hiploadmodule/main.cpp
+++ b/samples/hiploadmodule/main.cpp
@@ -9,127 +9,124 @@
 
 #define NUM 100
 
-#define CHECK(cmd)                                                                         \
-    do {                                                                                   \
-        hipError_t error = (cmd);                                                          \
-        if (error != hipSuccess) {                                                         \
-            fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error, \
-                    __FILE__, __LINE__);                                                   \
-            exit(1);                                                                       \
-        }                                                                                  \
-    } while(0)
+#define CHECK(cmd)                                                                   \
+  do {                                                                               \
+    hipError_t error = (cmd);                                                        \
+    if (error != hipSuccess) {                                                       \
+      fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error, \
+              __FILE__, __LINE__);                                                   \
+      exit(1);                                                                       \
+    }                                                                                \
+  } while(0)
 
 
 using namespace std;
 
 int main(int argc, char* argv[])
 {
-    // set up arrays for vector add
-    int i=0;
-    float* hostA;
-    float* hostB;
-    float* hostC;
+  // set up arrays for vector add
+  int i=0;
+  float* hostA;
+  float* hostB;
+  float* hostC;
 
-    float* deviceA;
-    float* deviceB;
-    float* deviceC;
+  float* deviceA;
+  float* deviceB;
+  float* deviceC;
 
-    struct {
-        size_t _n;
-        void* _Ad;
-        void* _Bd;
-        void* _Cd;
-    } args1;
+  struct {
+    size_t _n;
+    void* _Ad;
+    void* _Bd;
+    void* _Cd;
+  } args1;
 
-    hostA = (float*)malloc(NUM * sizeof(float));
-    hostB = (float*)malloc(NUM * sizeof(float));
-    hostC = (float*)malloc(NUM * sizeof(float));
+  hostA = (float*)malloc(NUM * sizeof(float));
+  hostB = (float*)malloc(NUM * sizeof(float));
+  hostC = (float*)malloc(NUM * sizeof(float));
 
-    // initialize the input data
-    for (i = 0; i < NUM; i++) {
-        hostA[i] = (float)i;
-        hostB[i] = (float)i;
+  // initialize the input data
+  for (i = 0; i < NUM; i++) {
+    hostA[i] = (float)i;
+    hostB[i] = (float)i;
+  }
+
+  CHECK(hipInit(0));
+  CHECK(hipMalloc((void**)&deviceA, NUM * sizeof(float)));
+  CHECK(hipMalloc((void**)&deviceB, NUM * sizeof(float)));
+  CHECK(hipMalloc((void**)&deviceC, NUM * sizeof(float)));
+
+  CHECK(hipMemcpy(deviceB, hostB, NUM*sizeof(float), hipMemcpyHostToDevice));
+  CHECK(hipMemcpy(deviceA, hostA, NUM*sizeof(float), hipMemcpyHostToDevice));
+
+  hipModule_t hipModule = NULL;
+  hipError_t error;
+
+  char result[ PATH_MAX ];
+  ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX );
+  std::string executablePath( result, (count > 0) ? count : 0 );
+  size_t last_pos = executablePath.find_last_of("/");
+  if (last_pos == std::string::npos)
+    executablePath.assign("./");
+  else
+    executablePath.resize(last_pos+1);
+  const std::string  binaryFilename(executablePath + "hipModuleLoadBinary");
+
+  error = hipModuleLoad(&hipModule, binaryFilename.c_str());
+  if (error) {
+    printf("%s\n",  binaryFilename.c_str());
+    cout << "Loading Module ("+binaryFilename+")" << endl;
+    exit(1);
+  }
+
+  // get the function from the module
+  hipFunction_t hipFunction = NULL;
+  error = hipModuleGetFunction(&hipFunction, hipModule, "_occa_addVectors_0");
+  if (error) {
+    cout << "Getting Function (_occa_addVectors_0)" << endl;
+    exit(1);
+  }
+
+  args1._n = NUM;
+  args1._Ad = deviceA;
+  args1._Bd = deviceB;
+  args1._Cd = deviceC;
+
+  size_t size = sizeof(args1);
+
+  void *config[] = {
+    HIP_LAUNCH_PARAM_BUFFER_POINTER, &args1,
+    HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+    HIP_LAUNCH_PARAM_END
+  };
+
+  // launch the function
+  error = hipModuleLaunchKernel( hipFunction, 1, 1, 1, NUM, 1, 1, 0, NULL, NULL,
+                                 reinterpret_cast<void**>(&config) );
+  if (error) {
+    cout << "hipmodulelaunch error" << endl;
+    exit(1);
+  }
+
+  CHECK(hipMemcpy(hostC, deviceC, NUM*sizeof(float), hipMemcpyDeviceToHost));
+
+  // verify the results
+  int errors = 0;
+  for (i = 0; i < NUM; i++) {
+    if (hostC[i] != (hostB[i] + hostA[i])) {
+      printf( "%f\n", hostC[i]);
+      errors++;
     }
+  }
+  if (errors!=0) {
+    printf("FAILED: %d errors\n",errors);
+  } else {
+    printf("PASSED!\n");
+  }
 
-    CHECK(hipInit(0));
-    CHECK(hipMalloc((void**)&deviceA, NUM * sizeof(float)));
-    CHECK(hipMalloc((void**)&deviceB, NUM * sizeof(float)));
-    CHECK(hipMalloc((void**)&deviceC, NUM * sizeof(float)));
+  CHECK(hipFree(deviceA));
+  CHECK(hipFree(deviceB));
+  CHECK(hipFree(deviceC));
 
-    CHECK(hipMemcpy(deviceB, hostB, NUM*sizeof(float), hipMemcpyHostToDevice));
-    CHECK(hipMemcpy(deviceA, hostA, NUM*sizeof(float), hipMemcpyHostToDevice));
-
-    hipModule_t hipModule = NULL;
-    hipError_t error;
-  
-    char result[ PATH_MAX ];
-    ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX );
-    std::string executablePath( result, (count > 0) ? count : 0 );
-    size_t last_pos = executablePath.find_last_of("/");
-    if (last_pos == std::string::npos)
-      executablePath.assign("./");
-    else
-      executablePath.resize(last_pos+1);
-    const std::string  binaryFilename(executablePath + "hipModuleLoadBinary");
-
-    error = hipModuleLoad(&hipModule, binaryFilename.c_str());
-    if (error) {
-        printf("%s\n",  binaryFilename.c_str());
-        cout << "Loading Module ("+binaryFilename+")" << endl;
-        exit(1);
-    }
-
-    // get the function from the module
-    hipFunction_t hipFunction = NULL;
-    error = hipModuleGetFunction(&hipFunction, hipModule, "_occa_addVectors_0");
-    if (error) {
-        cout << "Getting Function (_occa_addVectors_0)" << endl;
-        exit(1);
-    }
-
-
-    args1._n = NUM;
-    args1._Ad = deviceA;
-    args1._Bd = deviceB;
-    args1._Cd = deviceC;
-
-    size_t size = sizeof(args1);
-
-    void *config[] = {
-        HIP_LAUNCH_PARAM_BUFFER_POINTER, &args1,
-        HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
-        HIP_LAUNCH_PARAM_END
-    };
-
-
-    // launch the function
-    error = hipModuleLaunchKernel( hipFunction, 1, 1, 1, NUM, 1, 1, 0, NULL, NULL,
-                                   reinterpret_cast<void**>(&config) );
-    if (error) {
-      cout << "hipmodulelaunch error" << endl;
-      exit(1);
-    }
-
-    // free(output);
-    CHECK(hipMemcpy(hostC, deviceC, NUM*sizeof(float), hipMemcpyDeviceToHost));
-
-    // verify the results
-    int errors = 0;
-    for (i = 0; i < NUM; i++) {
-        if (hostC[i] != (hostB[i] + hostA[i])) {
-            printf( "%f\n", hostC[i]);
-            errors++;
-        }
-    }
-    if (errors!=0) {
-        printf("FAILED: %d errors\n",errors);
-    } else {
-        printf("PASSED!\n");
-    }
-
-    CHECK(hipFree(deviceA));
-    CHECK(hipFree(deviceB));
-    CHECK(hipFree(deviceC));
-
-    return 0;
+  return 0;
 }

--- a/samples/hiploadmodule/main.cpp
+++ b/samples/hiploadmodule/main.cpp
@@ -1,0 +1,135 @@
+#include <hip/hip_runtime.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <iostream>
+#include <string>
+#include <limits.h>
+#include <unistd.h>
+
+#define NUM 100
+
+#define CHECK(cmd)                                                                         \
+    do {                                                                                   \
+        hipError_t error = (cmd);                                                          \
+        if (error != hipSuccess) {                                                         \
+            fprintf(stderr, "error: '%s'(%d) at %s:%d\n", hipGetErrorString(error), error, \
+                    __FILE__, __LINE__);                                                   \
+            exit(1);                                                                       \
+        }                                                                                  \
+    } while(0)
+
+
+using namespace std;
+
+int main(int argc, char* argv[])
+{
+    // set up arrays for vector add
+    int i=0;
+    float* hostA;
+    float* hostB;
+    float* hostC;
+
+    float* deviceA;
+    float* deviceB;
+    float* deviceC;
+
+    struct {
+        size_t _n;
+        void* _Ad;
+        void* _Bd;
+        void* _Cd;
+    } args1;
+
+    hostA = (float*)malloc(NUM * sizeof(float));
+    hostB = (float*)malloc(NUM * sizeof(float));
+    hostC = (float*)malloc(NUM * sizeof(float));
+
+    // initialize the input data
+    for (i = 0; i < NUM; i++) {
+        hostA[i] = (float)i;
+        hostB[i] = (float)i;
+    }
+
+    CHECK(hipInit(0));
+    CHECK(hipMalloc((void**)&deviceA, NUM * sizeof(float)));
+    CHECK(hipMalloc((void**)&deviceB, NUM * sizeof(float)));
+    CHECK(hipMalloc((void**)&deviceC, NUM * sizeof(float)));
+
+    CHECK(hipMemcpy(deviceB, hostB, NUM*sizeof(float), hipMemcpyHostToDevice));
+    CHECK(hipMemcpy(deviceA, hostA, NUM*sizeof(float), hipMemcpyHostToDevice));
+
+    hipModule_t hipModule = NULL;
+    hipError_t error;
+  
+    char result[ PATH_MAX ];
+    ssize_t count = readlink( "/proc/self/exe", result, PATH_MAX );
+    std::string executablePath( result, (count > 0) ? count : 0 );
+    size_t last_pos = executablePath.find_last_of("/");
+    if (last_pos == std::string::npos)
+      executablePath.assign("./");
+    else
+      executablePath.resize(last_pos+1);
+    const std::string  binaryFilename(executablePath + "hipModuleLoadBinary");
+
+    error = hipModuleLoad(&hipModule, binaryFilename.c_str());
+    if (error) {
+        printf("%s\n",  binaryFilename.c_str());
+        cout << "Loading Module ("+binaryFilename+")" << endl;
+        exit(1);
+    }
+
+    // get the function from the module
+    hipFunction_t hipFunction = NULL;
+    error = hipModuleGetFunction(&hipFunction, hipModule, "_occa_addVectors_0");
+    if (error) {
+        cout << "Getting Function (_occa_addVectors_0)" << endl;
+        exit(1);
+    }
+
+
+    args1._n = NUM;
+    args1._Ad = deviceA;
+    args1._Bd = deviceB;
+    args1._Cd = deviceC;
+
+    size_t size = sizeof(args1);
+
+    void *config[] = {
+        HIP_LAUNCH_PARAM_BUFFER_POINTER, &args1,
+        HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+        HIP_LAUNCH_PARAM_END
+    };
+
+
+    // launch the function
+    error = hipModuleLaunchKernel( hipFunction, 1, 1, 1, NUM, 1, 1, 0, NULL, NULL,
+                                   reinterpret_cast<void**>(&config) );
+    if (error) {
+      cout << "hipmodulelaunch error" << endl;
+      exit(1);
+    }
+
+    // free(output);
+    CHECK(hipMemcpy(hostC, deviceC, NUM*sizeof(float), hipMemcpyDeviceToHost));
+
+    // verify the results
+    int errors = 0;
+    for (i = 0; i < NUM; i++) {
+        if (hostC[i] != (hostB[i] + hostA[i])) {
+            printf( "%f\n", hostC[i]);
+            errors++;
+        }
+    }
+    if (errors!=0) {
+        printf("FAILED: %d errors\n",errors);
+    } else {
+        printf("PASSED!\n");
+    }
+
+    CHECK(hipFree(deviceA));
+    CHECK(hipFree(deviceB));
+    CHECK(hipFree(deviceC));
+
+    return 0;
+}


### PR DESCRIPTION
Hello,

This patch:
 - allows `hipModuleLoad` to load a clang offload bundle as produced by `clang++`'s `--cuda-device-only` flag.
 - fixes `ClContext::launchWithExtraParams` when called with the extra parameter set
 - fixes `ClContext::launchWithExtraParams` and `ClContext::launchWithKernelParams` when used with the null stream.
 - adds a test for these functionalities except for `ClContext::launchWithKernelParams`

Thanks,

Colleen and Brice